### PR TITLE
Handle 'Any Time' as wildcard option

### DIFF
--- a/src/components/availability-matrix.tsx
+++ b/src/components/availability-matrix.tsx
@@ -63,10 +63,17 @@ export function AvailabilityMatrix({ data, onBestDateCalculated, onReset, onGoBa
           timeMap = new Map<string, number>();
           attendanceMap.set(dayKey, timeMap);
         }
-        timeMap.set(
-          availability.time,
-          (timeMap.get(availability.time) || 0) + 1
-        );
+
+        if (availability.time === "Any Time") {
+          for (const slot of TIME_ORDER) {
+            timeMap.set(slot, (timeMap.get(slot) || 0) + 1);
+          }
+        } else {
+          timeMap.set(
+            availability.time,
+            (timeMap.get(availability.time) || 0) + 1
+          );
+        }
       }
       availabilityMap.set(participant.name, dateMap);
     }
@@ -176,7 +183,9 @@ export function AvailabilityMatrix({ data, onBestDateCalculated, onReset, onGoBa
                     const isBestDate =
                       bestDateInfo.date?.getTime() === date.getTime();
                     const isBestDateTime =
-                      isBestDate && availableTime === bestDateInfo.time;
+                      isBestDate &&
+                      (availableTime === "Any Time" ||
+                        availableTime === bestDateInfo.time);
                     return (
                       <TableCell
                         key={date.toISOString()}


### PR DESCRIPTION
## Summary
- treat `Any Time` as a wildcard time slot when tallying availability
- highlight best time even if participant selected `Any Time`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_685a9a1502d48320964f018c03cdb97b