### PR TITLE
Fix searchParams usage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import type { AvailabilityData } from '@/lib/types';
 import type { SuggestRestaurantInput, SuggestRestaurantOutput } from '@/ai/flows/suggest-restaurant';
@@ -15,7 +15,7 @@ import { getRestaurantSuggestion } from './actions';
 import { useToast } from '@/hooks/use-toast';
 
 
-export default function Home() {
+function HomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -187,3 +187,12 @@ export default function Home() {
     </div>
   );
 }
+
+export default function Home() {
+  return (
+    <Suspense fallback={null}>
+      <HomeContent />
+    </Suspense>
+  );
+}
+


### PR DESCRIPTION
## Summary
- wrap search params usage in Suspense in the home page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685aa9be4a888320ad085352ce8e5338