### PR TITLE
Fix room auto deletion on first load

### DIFF
--- a/src/components/date-polling-form.tsx
+++ b/src/components/date-polling-form.tsx
@@ -105,6 +105,9 @@ export function DatePollingForm({ onSubmit, roomId }: DatePollingFormProps) {
   }, [replace, roomId]);
 
   const watchedParticipants = form.watch("participants");
+
+  const prevCountRef = React.useRef(0);
+
   React.useEffect(() => {
     const participantsToSave = watchedParticipants
       .filter(p => !p.isEditing)
@@ -116,9 +119,13 @@ export function DatePollingForm({ onSubmit, roomId }: DatePollingFormProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participants: participantsToSave }),
       }).catch(e => console.error('Failed to save participants', e));
-    } else {
-      fetch(`/api/rooms/${roomId}`, { method: 'DELETE' }).catch(e => console.error('Failed to delete room', e));
+    } else if (prevCountRef.current > 0) {
+      fetch(`/api/rooms/${roomId}`, { method: 'DELETE' }).catch(e =>
+        console.error('Failed to delete room', e)
+      );
     }
+
+    prevCountRef.current = participantsToSave.length;
   }, [watchedParticipants, roomId]);
 
   const handleFormSubmit = (values: z.infer<typeof formSchema>) => {


### PR DESCRIPTION
## Summary
- avoid deleting room data when participants list is empty on initial load

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685acf1b7a008320ba0ca63c7647f3b4