### PR TITLE
Fix missing DB columns on old databases

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -26,6 +26,21 @@ function init() {
     execFileSync('sqlite3', [DB_PATH], { input: '' });
   }
   run('CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, name TEXT, participants TEXT)');
+  // Upgrade schema for older databases missing columns
+  const schema = run('PRAGMA table_info(rooms)', true);
+  if (schema) {
+    try {
+      const columns = new Set((JSON.parse(schema) as any[]).map((c) => c.name));
+      if (!columns.has('name')) {
+        run('ALTER TABLE rooms ADD COLUMN name TEXT');
+      }
+      if (!columns.has('participants')) {
+        run('ALTER TABLE rooms ADD COLUMN participants TEXT');
+      }
+    } catch (e) {
+      console.error('Failed to ensure DB schema', e);
+    }
+  }
 }
 
 export function getParticipants(id: string): AvailabilityData | null {


### PR DESCRIPTION
## Summary
- ensure the `rooms` table includes `name` and `participants`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_685ada8ea4448320b16550d860ecbfe5