### PR TITLE
Fix room deletion trigger

### DIFF
--- a/src/components/date-polling-form.tsx
+++ b/src/components/date-polling-form.tsx
@@ -116,8 +116,6 @@ export function DatePollingForm({ onSubmit, roomId }: DatePollingFormProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participants: participantsToSave }),
       }).catch(e => console.error('Failed to save participants', e));
-    } else {
-      fetch(`/api/rooms/${roomId}`, { method: 'DELETE' }).catch(e => console.error('Failed to delete room', e));
     }
   }, [watchedParticipants, roomId]);
 


### PR DESCRIPTION
## Summary
- keep saved room data when visiting a room by removing automatic deletion in `DatePollingForm`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_b_685addc5c4fc8320ad7106f9380ced70