### PR TITLE
Fix dynamic room API params usage

### DIFF
--- a/src/app/api/rooms/[roomId]/route.ts
+++ b/src/app/api/rooms/[roomId]/route.ts
@@ -2,20 +2,23 @@ import { NextResponse } from 'next/server';
 import { getParticipants, saveParticipants, deleteParticipants } from '@/lib/db';
 
 export async function GET(req: Request, { params }: { params: { roomId: string } }) {
-  const participants = getParticipants(params.roomId) || [];
+  const roomId = params.roomId;
+  const participants = getParticipants(roomId) || [];
   return NextResponse.json({ participants });
 }
 
 export async function POST(req: Request, { params }: { params: { roomId: string } }) {
+  const roomId = params.roomId;
   const body = await req.json().catch(() => ({}));
   if (!Array.isArray(body.participants)) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
   }
-  saveParticipants(params.roomId, body.participants);
+  saveParticipants(roomId, body.participants);
   return NextResponse.json({ ok: true });
 }
 
 export async function DELETE(req: Request, { params }: { params: { roomId: string } }) {
-  deleteParticipants(params.roomId);
+  const roomId = params.roomId;
+  deleteParticipants(roomId);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- use `roomId` param before async operations in room API routes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_685adeab62048320956b2f6f37d47cb3