### PR TITLE
Add share room menu button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ server. To ensure everyone sees the same information:
 1. **Run a single server instance.** Start `npm run dev` on one machine and make
    sure other devices access the app via this server's URL.
 2. **Share the room link.** When a room is created, the page URL contains a
-   `?room=ID` query parameter. Share this full link (or use the "Share Link"
+   `?room=ID` query parameter. Share this full link (or use the "Share Your Room"
    button) so others join the exact same room.
 
 The server requires the `sqlite3` command line tool. If you encounter errors

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,6 +126,11 @@ function HomeContent() {
             GatherEase
           </h1>
         </a>
+        <div className="ml-auto">
+          <Button variant="outline" size="sm" onClick={handleCopyLink}>
+            Share Your Room
+          </Button>
+        </div>
       </header>
       <main className="flex flex-1 flex-col items-center gap-8 p-4 md:p-8">
         <div className="w-full max-w-4xl space-y-8">


### PR DESCRIPTION
## Summary
- add `Share Your Room` button in header to copy current link
- document Share Your Room button in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685ae25f74d88320b04ff1845c5e97a2