### PR TITLE
Fix uncontrolled input warning

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, value, ...props }, ref) => {
     return (
       <input
         type={type}
@@ -12,6 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
           className
         )}
         ref={ref}
+        value={value ?? ""}
         {...props}
       />
     )


### PR DESCRIPTION
## Summary
- ensure UI `Input` defaults to an empty value when `value` prop is `undefined`

## Testing
- `npm run typecheck` *(fails: 'searchParams' is possibly 'null')*

------
https://chatgpt.com/codex/tasks/task_b_685b6c18405c8321b8cd997adfec76bb