### PR TITLE
Handle empty price range

### DIFF
--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -32,7 +32,11 @@ const formSchema = z.object({
   location: z.string().min(3, "Please enter a valid city or address."),
   dietaryRestrictions: z.string().optional(),
   cuisine: z.string().optional(),
-  priceRange: z.enum(['$', '$$', '$$$']).optional(),
+  priceRange: z
+    .string()
+    .optional()
+    .transform(val => (val ? val : undefined))
+    .pipe(z.enum(['$', '$$', '$$$']).optional()),
   distanceKm: z
     .string()
     .optional()

--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -32,11 +32,10 @@ const formSchema = z.object({
   location: z.string().min(3, "Please enter a valid city or address."),
   dietaryRestrictions: z.string().optional(),
   cuisine: z.string().optional(),
-  priceRange: z
-    .string()
-    .optional()
-    .transform(val => (val ? val : undefined))
-    .pipe(z.enum(['$', '$$', '$$$']).optional()),
+  priceRange: z.preprocess(
+    val => typeof val === 'string' && val.trim() === '' ? undefined : val,
+    z.enum(['$', '$$', '$$$']).optional()
+  ),
   distanceKm: z
     .string()
     .optional()


### PR DESCRIPTION
## Summary
- handle empty price range option in the form

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_685b6e9fc904832192ec1d0417f8d3d8