### PR TITLE
Fix dynamic param awaiting

### DIFF
--- a/src/app/api/rooms/[roomId]/participants/route.ts
+++ b/src/app/api/rooms/[roomId]/participants/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server';
 import { getParticipants, mergeParticipantChanges, deleteParticipants } from '@/lib/db';
 
-export async function GET(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+export async function GET(
+  req: Request,
+  { params }: { params: { roomId: string } }
+) {
+  const { roomId } = await params;
   const participants = await getParticipants(roomId);
   return NextResponse.json({ participants });
 }
 
 export async function POST(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+  const { roomId } = await params;
   const body = await req.json().catch(() => ({}));
   if (!Array.isArray(body.changes)) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
@@ -18,7 +21,7 @@ export async function POST(req: Request, { params }: { params: { roomId: string 
 }
 
 export async function DELETE(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+  const { roomId } = await params;
   await deleteParticipants(roomId);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/rooms/[roomId]/route.ts
+++ b/src/app/api/rooms/[roomId]/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server';
 import { getParticipants, saveParticipants, deleteParticipants } from '@/lib/db';
 
-export async function GET(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+export async function GET(
+  req: Request,
+  { params }: { params: { roomId: string } }
+) {
+  const { roomId } = await params;
   const participants = await getParticipants(roomId);
   return NextResponse.json({ participants: participants || [] });
 }
 
 export async function POST(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+  const { roomId } = await params;
   const body = await req.json().catch(() => ({}));
   if (!Array.isArray(body.participants)) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
@@ -18,7 +21,7 @@ export async function POST(req: Request, { params }: { params: { roomId: string 
 }
 
 export async function DELETE(req: Request, { params }: { params: { roomId: string } }) {
-  const roomId = params.roomId;
+  const { roomId } = await params;
   await deleteParticipants(roomId);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- await `params` inside room API routes

## Testing
- `npm run typecheck` *(fails: Property 'broadcast' does not exist)*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_685b72b4fcb4832190863bece704b29f