### PR TITLE
Fix socket.io client path

### DIFF
--- a/src/hooks/use-realtime-room.ts
+++ b/src/hooks/use-realtime-room.ts
@@ -5,7 +5,7 @@ import { io, Socket } from 'socket.io-client';
 export function useRealtimeRoom(roomId: string) {
   useEffect(() => {
     if (!roomId) return;
-    const socket: Socket = io('/api/socket/io');
+    const socket: Socket = io({ path: '/api/socket/io' });
     socket.emit('join', roomId);
     return () => {
       socket.disconnect();


### PR DESCRIPTION
## Summary
- correct the socket.io client path in `useRealtimeRoom` hook

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails: type errors in project)*

------
https://chatgpt.com/codex/tasks/task_b_685b74fb226c8321a934feed4c465941