### PR TITLE
Move calendar save and remove share

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,9 +178,6 @@ function HomeContent() {
                   )}
                   Find New Suggestions
                 </Button>
-                <Button variant="outline" onClick={handleCopyLink}>
-                  Share Link
-                </Button>
               </div>
             </div>
           )}

--- a/src/components/availability-matrix.tsx
+++ b/src/components/availability-matrix.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useEffect } from "react";
 import type { AvailabilityData } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { cn, downloadCalendarEvent } from "@/lib/utils";
 import {
   Card,
   CardContent,
@@ -131,7 +131,7 @@ export function AvailabilityMatrix({ data, onBestDateCalculated, onReset, onGoBa
       </CardHeader>
       <CardContent>
         {bestDateInfo.date ? (
-          <div className="mb-6 rounded-lg border border-primary bg-primary/10 p-4 text-center">
+          <div className="mb-6 rounded-lg border border-primary bg-primary/10 p-4 text-center space-y-2">
              <h3 className="font-headline font-semibold text-lg text-primary">Best Time Found!</h3>
             <p className="text-muted-foreground">
               The best time for your get-together is{" "}
@@ -140,6 +140,9 @@ export function AvailabilityMatrix({ data, onBestDateCalculated, onReset, onGoBa
               <span className="font-bold text-foreground">{bestDateInfo.time}</span>, with{" "}
               <span className="font-bold text-foreground">{bestDateInfo.attendance} out of {data.length} people</span> available.
             </p>
+            <Button variant="outline" onClick={() => downloadCalendarEvent(bestDateInfo.date!, bestDateInfo.time!)}>
+              Save to Calendar
+            </Button>
           </div>
         ) : (
           <div className="mb-6 rounded-lg border border-destructive bg-destructive/10 p-4 text-center">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,43 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function downloadCalendarEvent(date: Date, time: string) {
+  const TIME_MAP: Record<string, string> = {
+    "Any Time": "12:00",
+    "Morning (9am-12pm)": "09:00",
+    "Afternoon (12pm-5pm)": "12:00",
+    "Evening (5pm-9pm)": "17:00",
+    "Late Night (9pm+)": "21:00",
+  };
+
+  const [hours, minutes] = (TIME_MAP[time] || "12:00").split(":");
+  const start = new Date(date);
+  start.setHours(Number(hours), Number(minutes), 0, 0);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+
+  const formatICS = (d: Date) =>
+    d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "BEGIN:VEVENT",
+    `DTSTAMP:${formatICS(new Date())}`,
+    `DTSTART:${formatICS(start)}`,
+    `DTEND:${formatICS(end)}`,
+    "SUMMARY:GatherEase Event",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "event.ics";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add a helper to download a calendar event
- show **Save to Calendar** button with Best Time message
- drop extra share button from suggestion section

## Testing
- `npm run lint` *(fails: asks for ESLint setup)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_685c0c8d6a50832189e7d8486392315e