### PR TITLE
Fix price range validation for 'Any' option

### DIFF
--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -31,7 +31,11 @@ import { Loader2, Sparkles } from "lucide-react";
 const formSchema = z.object({
   location: z.string().min(3, "Please enter a valid city or address."),
   dietaryRestrictions: z.string().optional(),
-  priceRange: z.enum(['$', '$$', '$$$']).optional(),
+  priceRange: z
+    .preprocess(
+      val => (val === '' ? undefined : val),
+      z.enum(['$', '$$', '$$$']).optional()
+    ),
   radius: z.string().optional(),
   cuisineTypes: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- handle `Any` option in restaurant price range selector

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_685c123046e88321bf9308c6f4fe272f