### PR TITLE
Improve availability info and km option

### DIFF
--- a/src/ai/flows/suggest-restaurant.ts
+++ b/src/ai/flows/suggest-restaurant.ts
@@ -18,7 +18,7 @@ const SuggestRestaurantInputSchema = z.object({
     .describe('Dietary restrictions for the group (e.g., vegetarian, vegan, gluten-free).'),
   location: z.string().describe('The location of the group (e.g., city, address).'),
   priceRange: z.enum(['$', '$$', '$$$']).optional().describe('Preferred price range'),
-  radius: z.number().int().optional().describe('Search radius in miles'),
+  radius: z.number().int().optional().describe('Search radius in kilometers'),
   cuisineTypes: z.string().optional().describe('Preferred cuisines or keywords'),
   excludedRestaurants: z.array(z.string()).optional().describe('A list of restaurant names to exclude from the suggestions.'),
 });
@@ -67,7 +67,7 @@ Location: {{{location}}}
 Price Range: {{{priceRange}}}
 {{/if}}
 {{#if radius}}
-Within {{{radius}}} miles
+Within {{{radius}}} km
 {{/if}}
 {{#if cuisineTypes}}
 Preferred Cuisines: {{{cuisineTypes}}}

--- a/src/components/availability-matrix.tsx
+++ b/src/components/availability-matrix.tsx
@@ -47,7 +47,7 @@ export function AvailabilityMatrix({
   onGoBack,
   onSaveCalendar,
 }: AvailabilityMatrixProps) {
-  const { uniqueDates, availabilityMap, bestDateInfo, rankedOptions } =
+  const { uniqueDates, availabilityMap, bestDateInfo, bestOptions, rankedOptions } =
     useMemo(() => {
       const allDates = data.flatMap((p) => p.availabilities.map((a) => a.date));
       const uniqueDateTimes = [
@@ -117,6 +117,10 @@ export function AvailabilityMatrix({
         return TIME_ORDER.indexOf(a.time) - TIME_ORDER.indexOf(b.time);
       });
 
+      const bestOptions = rankedOptions.filter(
+        (opt) => opt.attendance === maxAttendance,
+      );
+
       return {
         uniqueDates,
         availabilityMap,
@@ -125,6 +129,7 @@ export function AvailabilityMatrix({
           time: bestTime,
           attendance: maxAttendance,
         },
+        bestOptions,
         rankedOptions,
       };
     }, [data]);
@@ -147,23 +152,33 @@ export function AvailabilityMatrix({
         {bestDateInfo.date ? (
           <div className="mb-6 rounded-lg border border-primary bg-primary/10 p-4 text-center">
             <h3 className="font-headline font-semibold text-lg text-primary">
-              Best Time Found!
+              {bestOptions.length > 1 ? 'Best Times Found!' : 'Best Time Found!'}
             </h3>
-            <p className="text-muted-foreground">
-              The best time for your get-together is{" "}
-              <span className="font-bold text-foreground">
-                {format(bestDateInfo.date, "EEEE, MMMM do")}
-              </span>{" "}
-              at{" "}
-              <span className="font-bold text-foreground">
-                {bestDateInfo.time}
-              </span>
-              , with{" "}
-              <span className="font-bold text-foreground">
-                {bestDateInfo.attendance} out of {data.length} people
-              </span>{" "}
-              available.
-            </p>
+            {bestOptions.length > 1 ? (
+              <div className="text-muted-foreground">
+                <p>We've found multiple times that work equally well:</p>
+                <ol className="mt-2 list-decimal list-inside space-y-1">
+                  {bestOptions.map(opt => (
+                    <li key={`${opt.date.toISOString()}-${opt.time}`}>
+                      {format(opt.date, 'EEEE, MMMM do')} at {opt.time} – {opt.attendance} / {data.length}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">
+                The best time for your get-together is{' '}
+                <span className="font-bold text-foreground">
+                  {format(bestDateInfo.date, 'EEEE, MMMM do')}
+                </span>{' '}
+                at{' '}
+                <span className="font-bold text-foreground">{bestDateInfo.time}</span>, with{' '}
+                <span className="font-bold text-foreground">
+                  {bestDateInfo.attendance} out of {data.length} people
+                </span>{' '}
+                available.
+              </p>
+            )}
             <Button className="mt-2" variant="outline" onClick={onSaveCalendar}>
               Save to Calendar
             </Button>
@@ -179,13 +194,13 @@ export function AvailabilityMatrix({
             </p>
           </div>
         )}
-        {bestDateInfo.date && rankedOptions.length > 1 && (
+        {bestDateInfo.date && rankedOptions.length > bestOptions.length && (
           <div className="mb-6 rounded-lg border bg-muted/20 p-4">
             <h4 className="font-headline font-semibold text-lg">
               Next Best Options
             </h4>
             <ol className="mt-2 list-decimal list-inside space-y-1 text-muted-foreground">
-              {rankedOptions.slice(1, 4).map((opt) => (
+              {rankedOptions.slice(bestOptions.length, bestOptions.length + 3).map((opt) => (
                 <li key={`${opt.date.toISOString()}-${opt.time}`}>
                   {format(opt.date, "EEEE, MMMM do")} at {opt.time} –{" "}
                   {opt.attendance} / {data.length}

--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -148,7 +148,7 @@ export function RestaurantSuggestionForm({ onSuggestion }: RestaurantSuggestionF
               name="radius"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Distance (miles)</FormLabel>
+                  <FormLabel>Distance (km)</FormLabel>
                   <FormControl>
                     <Input placeholder="e.g., 5" {...field} />
                   </FormControl>


### PR DESCRIPTION
## Summary
- show all best time options on the availability results view
- slice next best options after the top ties
- switch restaurant distance field to kilometers
- reflect km radius in the restaurant suggestion agent

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' and other declarations)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c145038e8832194ab4469d522fdaf