### PR TITLE
Add multiple best times and km distance

### DIFF
--- a/src/ai/flows/suggest-restaurant.ts
+++ b/src/ai/flows/suggest-restaurant.ts
@@ -18,7 +18,7 @@ const SuggestRestaurantInputSchema = z.object({
     .describe('Dietary restrictions for the group (e.g., vegetarian, vegan, gluten-free).'),
   location: z.string().describe('The location of the group (e.g., city, address).'),
   priceRange: z.enum(['$', '$$', '$$$']).optional().describe('Preferred price range'),
-  radius: z.number().int().optional().describe('Search radius in miles'),
+  radius: z.number().int().optional().describe('Search radius in km'),
   cuisineTypes: z.string().optional().describe('Preferred cuisines or keywords'),
   excludedRestaurants: z.array(z.string()).optional().describe('A list of restaurant names to exclude from the suggestions.'),
 });
@@ -67,7 +67,7 @@ Location: {{{location}}}
 Price Range: {{{priceRange}}}
 {{/if}}
 {{#if radius}}
-Within {{{radius}}} miles
+Within {{{radius}}} km
 {{/if}}
 {{#if cuisineTypes}}
 Preferred Cuisines: {{{cuisineTypes}}}

--- a/src/components/availability-matrix.tsx
+++ b/src/components/availability-matrix.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import type { AvailabilityData } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { CheckCircle2, XCircle, Users, ArrowLeft } from "lucide-react";
 import { format, startOfDay } from "date-fns";
 
@@ -47,7 +48,7 @@ export function AvailabilityMatrix({
   onGoBack,
   onSaveCalendar,
 }: AvailabilityMatrixProps) {
-  const { uniqueDates, availabilityMap, bestDateInfo, rankedOptions } =
+  const { uniqueDates, availabilityMap, bestOptions, rankedOptions, bestDateInfo } =
     useMemo(() => {
       const allDates = data.flatMap((p) => p.availabilities.map((a) => a.date));
       const uniqueDateTimes = [
@@ -117,6 +118,10 @@ export function AvailabilityMatrix({
         return TIME_ORDER.indexOf(a.time) - TIME_ORDER.indexOf(b.time);
       });
 
+      const bestOptions = rankedOptions.filter(
+        (opt) => opt.attendance === maxAttendance,
+      );
+
       return {
         uniqueDates,
         availabilityMap,
@@ -125,13 +130,21 @@ export function AvailabilityMatrix({
           time: bestTime,
           attendance: maxAttendance,
         },
+        bestOptions,
         rankedOptions,
       };
     }, [data]);
 
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const selectedOption = bestOptions[selectedIndex] ?? null;
+
   useEffect(() => {
-    onBestDateCalculated(bestDateInfo.date, bestDateInfo.time);
-  }, [bestDateInfo.date, bestDateInfo.time, onBestDateCalculated]);
+    if (selectedOption) {
+      onBestDateCalculated(selectedOption.date, selectedOption.time);
+    } else {
+      onBestDateCalculated(null, null);
+    }
+  }, [selectedOption, onBestDateCalculated]);
 
   return (
     <Card className="w-full max-w-4xl shadow-lg">
@@ -144,26 +157,50 @@ export function AvailabilityMatrix({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {bestDateInfo.date ? (
+        {bestOptions.length ? (
           <div className="mb-6 rounded-lg border border-primary bg-primary/10 p-4 text-center">
             <h3 className="font-headline font-semibold text-lg text-primary">
-              Best Time Found!
+              {bestOptions.length > 1 ? "Best Times Found!" : "Best Time Found!"}
             </h3>
-            <p className="text-muted-foreground">
-              The best time for your get-together is{" "}
-              <span className="font-bold text-foreground">
-                {format(bestDateInfo.date, "EEEE, MMMM do")}
-              </span>{" "}
-              at{" "}
-              <span className="font-bold text-foreground">
-                {bestDateInfo.time}
-              </span>
-              , with{" "}
-              <span className="font-bold text-foreground">
-                {bestDateInfo.attendance} out of {data.length} people
-              </span>{" "}
-              available.
-            </p>
+            {bestOptions.length > 1 ? (
+              <div className="mt-2 flex flex-col items-start justify-center gap-2">
+                <p className="text-muted-foreground">
+                  Multiple times work equally well. Select one to save:
+                </p>
+                <RadioGroup
+                  value={String(selectedIndex)}
+                  onValueChange={(val) => setSelectedIndex(parseInt(val))}
+                >
+                  {bestOptions.map((opt, idx) => (
+                    <label
+                      key={`${opt.date.toISOString()}-${opt.time}`}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <RadioGroupItem value={String(idx)} id={`best-${idx}`} />
+                      <span>
+                        {format(opt.date, "EEEE, MMMM do")} at {opt.time} – {opt.attendance} / {data.length}
+                      </span>
+                    </label>
+                  ))}
+                </RadioGroup>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">
+                The best time for your get-together is{' '}
+                <span className="font-bold text-foreground">
+                  {format(selectedOption!.date, "EEEE, MMMM do")}
+                </span>{' '}
+                at{' '}
+                <span className="font-bold text-foreground">
+                  {selectedOption!.time}
+                </span>
+                , with{' '}
+                <span className="font-bold text-foreground">
+                  {selectedOption!.attendance} out of {data.length} people
+                </span>{' '}
+                available.
+              </p>
+            )}
             <Button className="mt-2" variant="outline" onClick={onSaveCalendar}>
               Save to Calendar
             </Button>
@@ -179,18 +216,20 @@ export function AvailabilityMatrix({
             </p>
           </div>
         )}
-        {bestDateInfo.date && rankedOptions.length > 1 && (
+        {bestOptions.length && rankedOptions.length > bestOptions.length && (
           <div className="mb-6 rounded-lg border bg-muted/20 p-4">
             <h4 className="font-headline font-semibold text-lg">
               Next Best Options
             </h4>
             <ol className="mt-2 list-decimal list-inside space-y-1 text-muted-foreground">
-              {rankedOptions.slice(1, 4).map((opt) => (
-                <li key={`${opt.date.toISOString()}-${opt.time}`}>
-                  {format(opt.date, "EEEE, MMMM do")} at {opt.time} –{" "}
-                  {opt.attendance} / {data.length}
-                </li>
-              ))}
+              {rankedOptions
+                .slice(bestOptions.length, bestOptions.length + 3)
+                .map((opt) => (
+                  <li key={`${opt.date.toISOString()}-${opt.time}`}>
+                    {format(opt.date, "EEEE, MMMM do")} at {opt.time} –{' '}
+                    {opt.attendance} / {data.length}
+                  </li>
+                ))}
             </ol>
           </div>
         )}
@@ -204,7 +243,7 @@ export function AvailabilityMatrix({
                 </TableHead>
                 {uniqueDates.map((date) => {
                   const isBestDate =
-                    bestDateInfo.date?.getTime() === date.getTime();
+                    selectedOption?.date.getTime() === date.getTime();
                   return (
                     <TableHead
                       key={date.toISOString()}
@@ -222,7 +261,7 @@ export function AvailabilityMatrix({
                           variant="default"
                           className="mt-1 bg-accent text-accent-foreground"
                         >
-                          Best {bestDateInfo.time?.replace(/\s\(.*\)/, "")}
+                          Best {selectedOption?.time.replace(/\s\(.*\)/, "")}
                         </Badge>
                       )}
                     </TableHead>
@@ -249,13 +288,13 @@ export function AvailabilityMatrix({
                       .get(participant.name)
                       ?.get(key);
                     const isBestDate =
-                      bestDateInfo.date?.getTime() === date.getTime();
+                      selectedOption?.date.getTime() === date.getTime();
                     const isBestDateTime =
                       isBestDate &&
                       availableTimes &&
                       (availableTimes.has("Any Time") ||
-                        (bestDateInfo.time
-                          ? availableTimes.has(bestDateInfo.time)
+                        (selectedOption?.time
+                          ? availableTimes.has(selectedOption.time)
                           : false));
                     return (
                       <TableCell

--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -148,7 +148,7 @@ export function RestaurantSuggestionForm({ onSuggestion }: RestaurantSuggestionF
               name="radius"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Distance (miles)</FormLabel>
+                  <FormLabel>Distance (km)</FormLabel>
                   <FormControl>
                     <Input placeholder="e.g., 5" {...field} />
                   </FormControl>


### PR DESCRIPTION
## Summary
- allow selection among multiple best meeting times in availability results
- display search distance in kilometers

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_b_685c148965c88321a3fbbc916c4d7705