### PR TITLE
Enable Postgres backend for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ npm run build
 
 and then start the server with `npm start`.
 
+## Deploying to Vercel
+
+Vercel's serverless functions run on a read-only filesystem, so the local
+`db.sqlite` file cannot be created. GatherEase automatically connects to a
+Postgres database when the `POSTGRES_URL` environment variable is defined.
+Provision a Vercel Postgres instance (or any external Postgres database) and set
+`POSTGRES_URL` in your project settings. If this variable is not set, the app
+falls back to the local SQLite database.
+
 ## Notes
 
 The AI flow relies on environment variables for authentication with Google AI

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "lucide-react": "^0.475.0",
         "next": "15.3.3",
         "patch-package": "^8.0.0",
+        "pg": "^8.16.2",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -51,7 +52,9 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
+        "@types/pg": "^8.15.4",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "genkit-cli": "^1.8.0",
@@ -4150,6 +4153,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -4240,6 +4253,18 @@
       "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -8133,6 +8158,95 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
+    "node_modules/pg": {
+      "version": "8.16.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.2.tgz",
+      "integrity": "sha512-OtLWF0mKLmpxelOt9BqVq83QV6bTfsS0XLegIeAKqKjurRnRKie1Dc1iL89MugmSLhftxw6NNCyZhm1yQFLMEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.2",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.6"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.6.tgz",
+      "integrity": "sha512-uxmJAnmIgmYgnSFzgOf2cqGQBzwnRYcrEgXuFjJNEkpedEIPBSEzxY7ph4uA9k1mI+l/GR0HjPNS6FKNZe8SBQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.2.tgz",
+      "integrity": "sha512-Ci7jy8PbaWxfsck2dwZdERcDG2A0MG8JoQILs+uZNjABFuBuItAZCWUNz8sXRDMoui24rJw7WlXqgpMdBSN/vQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8300,6 +8414,45 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -9308,6 +9461,15 @@
         "node": "*"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -10295,6 +10457,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",
+    "pg": "^8.16.2",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -55,7 +56,9 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
+    "@types/pg": "^8.15.4",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "genkit-cli": "^1.8.0",

--- a/src/app/api/rooms/[roomId]/route.ts
+++ b/src/app/api/rooms/[roomId]/route.ts
@@ -3,7 +3,7 @@ import { getParticipants, saveParticipants, deleteParticipants } from '@/lib/db'
 
 export async function GET(req: Request, { params }: { params: { roomId: string } }) {
   const roomId = params.roomId;
-  const participants = getParticipants(roomId) || [];
+  const participants = (await getParticipants(roomId)) || [];
   return NextResponse.json({ participants });
 }
 
@@ -13,12 +13,12 @@ export async function POST(req: Request, { params }: { params: { roomId: string 
   if (!Array.isArray(body.participants)) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
   }
-  saveParticipants(roomId, body.participants);
+  await saveParticipants(roomId, body.participants);
   return NextResponse.json({ ok: true });
 }
 
 export async function DELETE(req: Request, { params }: { params: { roomId: string } }) {
   const roomId = params.roomId;
-  deleteParticipants(roomId);
+  await deleteParticipants(roomId);
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,46 +1,93 @@
 import Database from 'better-sqlite3';
+import { Pool } from 'pg';
 import path from 'path';
 import type { AvailabilityData } from './types';
 
 const DB_PATH = path.join(process.cwd(), 'db.sqlite');
+const POSTGRES_URL = process.env.POSTGRES_URL || process.env.DATABASE_URL;
 
-let db: any | null = null;
+let sqlite: any | null = null;
+let pool: Pool | null = null;
+let dbType: 'sqlite' | 'postgres' | null = null;
 
-function init() {
-  if (!db) {
-    db = new Database(DB_PATH);
-    db.prepare('CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, participants TEXT)').run();
+async function init() {
+  if (dbType) return;
+  if (POSTGRES_URL) {
+    pool = new Pool({ connectionString: POSTGRES_URL });
+    await pool.query(
+      'CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, participants TEXT)'
+    );
+    dbType = 'postgres';
+  } else {
+    sqlite = new Database(DB_PATH);
+    sqlite
+      .prepare('CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, participants TEXT)')
+      .run();
+    dbType = 'sqlite';
   }
 }
 
-export function getParticipants(id: string): AvailabilityData | null {
-  init();
-  const row = db!.prepare('SELECT participants FROM rooms WHERE id=?').get(id);
-  if (!row) return null;
-  try {
-    const participants = JSON.parse(row.participants);
-    participants.forEach((p: any) => {
-      p.availabilities = p.availabilities.map((a: any) => ({
-        date: new Date(a.date),
-        times: Array.isArray(a.times) ? a.times : [a.time].filter(Boolean),
-      }));
-    });
-    return participants;
-  } catch (e) {
-    console.error('Failed to parse DB output', e);
-    return null;
+export async function getParticipants(id: string): Promise<AvailabilityData | null> {
+  await init();
+  if (dbType === 'postgres') {
+    const res = await pool!.query('SELECT participants FROM rooms WHERE id=$1', [id]);
+    if (res.rows.length === 0) return null;
+    try {
+      const participants = JSON.parse(res.rows[0].participants);
+      participants.forEach((p: any) => {
+        p.availabilities = p.availabilities.map((a: any) => ({
+          date: new Date(a.date),
+          times: Array.isArray(a.times) ? a.times : [a.time].filter(Boolean),
+        }));
+      });
+      return participants;
+    } catch (e) {
+      console.error('Failed to parse DB output', e);
+      return null;
+    }
+  } else {
+    const row = sqlite!
+      .prepare('SELECT participants FROM rooms WHERE id=?')
+      .get(id);
+    if (!row) return null;
+    try {
+      const participants = JSON.parse(row.participants);
+      participants.forEach((p: any) => {
+        p.availabilities = p.availabilities.map((a: any) => ({
+          date: new Date(a.date),
+          times: Array.isArray(a.times) ? a.times : [a.time].filter(Boolean),
+        }));
+      });
+      return participants;
+    } catch (e) {
+      console.error('Failed to parse DB output', e);
+      return null;
+    }
   }
 }
 
-export function saveParticipants(id: string, participants: AvailabilityData) {
-  init();
+export async function saveParticipants(id: string, participants: AvailabilityData) {
+  await init();
   const data = JSON.stringify(participants);
-  db!.prepare(
-    'INSERT INTO rooms (id, participants) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET participants=?'
-  ).run(id, data, data);
+  if (dbType === 'postgres') {
+    await pool!.query(
+      'INSERT INTO rooms (id, participants) VALUES ($1, $2) ON CONFLICT(id) DO UPDATE SET participants=$2',
+      [id, data]
+    );
+  } else {
+    sqlite!
+      .prepare(
+        'INSERT INTO rooms (id, participants) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET participants=?'
+      )
+      .run(id, data, data);
+  }
 }
 
-export function deleteParticipants(id: string) {
-  init();
-  db!.prepare('DELETE FROM rooms WHERE id=?').run(id);
+export async function deleteParticipants(id: string) {
+  await init();
+  if (dbType === 'postgres') {
+    await pool!.query('DELETE FROM rooms WHERE id=$1', [id]);
+  } else {
+    sqlite!.prepare('DELETE FROM rooms WHERE id=?').run(id);
+  }
 }


### PR DESCRIPTION
## Summary
- allow API server to use Postgres when `POSTGRES_URL` is set
- update API route to await new async DB helpers
- document Vercel deployment instructions
- add `pg` plus type packages

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_685cba8a4338832182053f5eaf437cfa