### PR TITLE
Improve spacing in UI components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -173,7 +173,7 @@ function HomeContent() {
           </Button>
         </div>
       </header>
-      <main className="flex flex-1 flex-col items-center gap-8 p-4 md:p-8">
+      <main className="flex flex-1 flex-col items-center gap-10 p-6 md:p-12">
         <div className="w-full max-w-4xl space-y-8">
           {!availability && (
             <div className="animate-in fade-in-0 slide-in-from-top-4 duration-500">

--- a/src/components/availability-matrix.tsx
+++ b/src/components/availability-matrix.tsx
@@ -303,7 +303,7 @@ export function AvailabilityMatrix({
                     <TableHead
                       key={date.toISOString()}
                       className={cn(
-                        "text-center min-w-[120px] p-2",
+                        "text-center min-w-[120px] px-3 py-2 sm:py-3",
                         isBestDate && "bg-primary/10",
                       )}
                     >
@@ -356,7 +356,7 @@ export function AvailabilityMatrix({
                       <TableCell
                         key={date.toISOString()}
                         className={cn(
-                          "text-center align-top p-2",
+                          "text-center align-top px-3 py-2 sm:py-3",
                           isBestDate && "bg-primary/5",
                           isBestDateTime && "outline outline-2 outline-offset-[-2px] outline-primary",
                         )}

--- a/src/components/date-polling-form.tsx
+++ b/src/components/date-polling-form.tsx
@@ -166,10 +166,10 @@ export function DatePollingForm({ onSubmit, roomId }: DatePollingFormProps) {
       </CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleFormSubmit)}>
-          <CardContent className="space-y-6">
+          <CardContent className="space-y-6 p-6 sm:p-8">
             <div className="space-y-4 min-h-[10rem]">
               {fields.length === 0 && (
-                 <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/20 h-full p-8 text-center">
+                 <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/20 h-full p-8 sm:p-12 text-center">
                     <p className="text-muted-foreground font-semibold">No participants yet.</p>
                     <p className="text-muted-foreground text-sm">Click the button below to add someone to the plan.</p>
                  </div>
@@ -385,7 +385,7 @@ export function DatePollingForm({ onSubmit, roomId }: DatePollingFormProps) {
               Add Participant
             </Button>
           </CardContent>
-          <CardFooter className="flex justify-end">
+          <CardFooter className="flex justify-end p-4 sm:p-6">
             <Button
               type="submit"
               size="lg"

--- a/src/components/restaurant-result-card.tsx
+++ b/src/components/restaurant-result-card.tsx
@@ -50,7 +50,7 @@ export function RestaurantResultCard({ data, rank }: RestaurantResultCardProps) 
           <span className="font-headline text-3xl font-bold text-primary">#{rank}</span>
         </div>
         <div className="flex-1">
-          <CardContent className="space-y-4 p-6">
+          <CardContent className="space-y-4 p-6 sm:p-8">
             <h3 className="font-headline text-2xl font-bold">{data.restaurantName}</h3>
             
             <div className="flex items-center gap-2 text-muted-foreground">
@@ -76,7 +76,7 @@ export function RestaurantResultCard({ data, rank }: RestaurantResultCardProps) 
               />
             </div>
           </CardContent>
-          <CardFooter className="flex justify-end bg-muted/50 p-4">
+          <CardFooter className="flex justify-end bg-muted/50 p-4 sm:p-6">
             <Button asChild variant="default" className="bg-primary text-primary-foreground">
               <a href={data.googleMapsUrl} target="_blank" rel="noopener noreferrer">
                 View on Google Maps <ExternalLink className="ml-2 h-4 w-4"/>

--- a/src/components/restaurant-suggestion-form.tsx
+++ b/src/components/restaurant-suggestion-form.tsx
@@ -99,7 +99,7 @@ export function RestaurantSuggestionForm({ onSuggestion }: RestaurantSuggestionF
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleFormSubmit)}>
                     <fieldset disabled={isLoading}>
-            <CardContent className="space-y-8">
+            <CardContent className="space-y-8 p-6 sm:p-8">
             <FormField
               control={form.control}
               name="location"
@@ -220,7 +220,7 @@ export function RestaurantSuggestionForm({ onSuggestion }: RestaurantSuggestionF
             </div>
                       </CardContent>
           </fieldset>
-          <CardFooter className="flex justify-end">
+          <CardFooter className="flex justify-end p-4 sm:p-6">
             <Button type="submit" size="lg" disabled={isLoading} className="bg-primary text-primary-foreground hover:bg-primary/90">
               {isLoading ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Summary
- tune global spacing on the home page
- refine spacing in the availability matrix table
- improve padding in the date polling form
- adjust padding on restaurant suggestion form
- widen layout of restaurant result cards

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_685e52f2bfd083219cdf8c68714afe4a